### PR TITLE
allow higher version of websockets to avoid clash with core ring 

### DIFF
--- a/custom_components/steamvr/manifest.json
+++ b/custom_components/steamvr/manifest.json
@@ -8,6 +8,6 @@
   "iot_class": "local_push",
   "issue_tracker": "https://github.com/Antoni-Czaplicki/SteamVR.HA/issues",
   "loggers": ["steamvr"],
-  "requirements": ["websockets==12.0"],
+  "requirements": ["websockets>=12.0,<14"],
   "version": "0.3.3"
 }


### PR DESCRIPTION
solves issue https://github.com/Antoni-Czaplicki/SteamVR.HA/issues/1

will stop the integration stopping the core ring integration from running after 2024.11.2 upgrade

changed to allow higher versions than 12.0 but below 14, this is because there may be some breaking changes above that. some testing and potential changes should happen before upgrading higher.